### PR TITLE
Load native WireGuard kernel module

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ the package version you want to install and download the selected Debian package
 for instance:
 
 ```bash
-wget https://github.com/fabianishere/udm-kernel-tools/releases/download/v1.1.3/udm-kernel-tools_1.1.3_arm64.deb
-apt install ./udm-kernel-tools_1.1.3_arm64.deb
+wget https://github.com/fabianishere/udm-kernel-tools/releases/download/v1.1.4/udm-kernel-tools_1.1.3_arm64.deb
+apt install ./udm-kernel-tools_1.1.4_arm64.deb
 ```
 
 ### Installing a custom kernel

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+udm-kernel-tools (1.1.4) stable; urgency=medium
+
+  * Fix issue with incompatible WireGuard module
+
+ -- Fabian Mastenbroek <mail.fabianm@gmail.com>  Wed, 9 Mar 2022 11:00:00 +0100
+
 udm-kernel-tools (1.1.3) stable; urgency=medium
 
   * Add support for firmware version 1.11.4.

--- a/udm-init
+++ b/udm-init
@@ -48,7 +48,7 @@ setup_modprobe_config() {
     KERNEL_MODDIR=$(find "$OVERLAY_ROOT"/lib/modules/ -mindepth 1 -maxdepth 1 -type d | head -n1)
     KERNEL_RELEASE=$(basename "$KERNEL_MODDIR")
     if [ -d "$KERNEL_MODDIR/extra" ]; then
-        find "$KERNEL_MODDIR/extra" -name '*.ko' \
+        find "$KERNEL_MODDIR/extra" -name '*.ko' -not -name 'wireguard.ko' \
             | sed "s/.*\///; s/\.ko//" \
             | awk "{print \"install \" \$0 \" /sbin/modprobe --ignore-install -f -S $KERNEL_RELEASE \" \$0}" \
             > "$OVERLAY_UPPER"/etc/modprobe.d/udm-kernel-tools.conf


### PR DESCRIPTION
This change fixes the init script to ignore the WireGuard module shipped
in the Ubiquiti stock firmware. This module is not compatible with
custom kernels. See the following issue:
https://github.com/fabianishere/udm-kernel/issues/13

Currently, the init script will configure modprobe to force-load
Ubiquiti's WireGuard version. This change updates it to ignore that
WireGuard kernel module, in order to use the native module.